### PR TITLE
Add tooling to build and sync SQLite datasets

### DIFF
--- a/csv_viewer_app/README.md
+++ b/csv_viewer_app/README.md
@@ -1,79 +1,66 @@
-# Getting Started with Create React App
+# Tuva Terminology Viewer
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+The CSV viewer is responsible for presenting Tuva's public terminology exports.
+In addition to the standard Create React App scripts, the project includes
+helpers for generating the header crosswalk JSON and the SQLite bundles that
+power the streaming search experience in production.
 
 ## Header Crosswalk
 
-This viewer now hydrates CSV headers from the Tuva dbt project so that the data exported to S3 can be rendered with friendly column names.
+This viewer hydrates CSV headers from the Tuva dbt project so that exported
+datasets render with friendly column names.
 
-- `npm run generate:crosswalk` builds `public/data/header-crosswalk.json` by inspecting every tagged release in the [`tuva`](https://github.com/tuva-health/tuva) repository. The script keeps a shallow clone under `scripts/.cache/tuva` (ignored in git).
-- The crosswalk step runs automatically before `npm start`, `npm run build`, and `npm test`. To skip a refresh you can set `TUVA_CROSSWALK_SKIP_FETCH=1` (reuse the existing clone) or `TUVA_CROSSWALK_DISABLE=1` (skip the step entirely).
-- Set `TUVA_REPO_URL`, `TUVA_REPO_DIR`, or `TUVA_CROSSWALK_OUTPUT` to override the default source repository, cache location, or output file.
-- When working without network access, generate the crosswalk once manually (or copy an existing JSON file) and reuse it locally via `TUVA_CROSSWALK_SKIP_FETCH=1`.
+- `npm run generate:crosswalk` builds `public/data/header-crosswalk.json` by
+  inspecting every tagged release in the [`tuva`](https://github.com/tuva-health/tuva)
+  repository. The script keeps a shallow clone under `scripts/.cache/tuva`
+  (ignored in git).
+- The crosswalk step runs automatically before `npm start`, `npm run build`,
+  and `npm test`. To skip a refresh you can set `TUVA_CROSSWALK_SKIP_FETCH=1`
+  (reuse the existing clone) or `TUVA_CROSSWALK_DISABLE=1` (skip the step
+  entirely).
+- Set `TUVA_REPO_URL`, `TUVA_REPO_DIR`, or `TUVA_CROSSWALK_OUTPUT` to override
+  the default source repository, cache location, or output file.
+- When working without network access, generate the crosswalk once manually (or
+  copy an existing JSON file) and reuse it locally via
+  `TUVA_CROSSWALK_SKIP_FETCH=1`.
+
+## SQLite search bundles
+
+- `npm run build:sqlite -- --input <path/to/dataset.csv[.gz]> --dataset <id>`
+  prepares the SQLite/FTS artefacts used by the worker. The command supports
+  gzipped Tuva exports out of the box and writes the output under
+  `public/data/sqlite/<datasetId>/` while refreshing
+  `public/data/sqlite/datasets.json`.
+- `npm run build:sqlite:batch -- <source>` scans an entire folder (for example
+  `../data/versioned_terminology/latest`) and invokes the builder for every
+  dataset whose row-count exceeds the preview threshold. Files ending in
+  `_compressed` are skipped automatically because they duplicate the canonical
+  exports.
+- `npm run sync:sqlite-assets -- <sources...>` syncs the published bundle set
+  down from S3 (`s3://tuva-public-resources/terminology_viewer_sqlite` by
+  default), runs the batch builder, and pushes refreshed artefacts back to the
+  same prefix. Add `--download-only` to hydrate the local cache without
+  rebuilding, or `--skip-download` / `--skip-upload` to control each sync
+  direction.
+- Column headers come from `public/data/header-crosswalk.json` when available;
+  pass `--crosswalk` if you need to point at a different file.
+- Sharding is automatic once the estimated shard size exceeds ~120 MB. Override
+  with `--max-shard-bytes`, `--shard-count`, or `--shard-key` if you need
+  deterministic splits.
+- Preview payloads can be disabled with `--skip-preview` or resized with
+  `--preview-limit`.
+- `npm run prepare:sqlite-assets` stages the `sql.js` wasm and worker bundles
+  into `public/sqljs/`; this runs automatically before `npm start`, `npm test`,
+  and `npm run build`.
 
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm start`
+- `npm start` – Runs the app in development mode.
+- `npm test` – Launches the test runner in interactive watch mode.
+- `npm run build` – Builds the app for production to the `build` folder.
+- `npm run eject` – Ejects the Create React App configuration.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+See the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started)
+for more details about the default scripts.

--- a/csv_viewer_app/package.json
+++ b/csv_viewer_app/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "better-sqlite3": "^11.5.0",
     "http-proxy-middleware": "^3.0.5",
     "jszip": "^3.10.1",
     "lucide-react": "^0.507.0",
@@ -20,9 +21,13 @@
   },
   "scripts": {
     "generate:crosswalk": "node scripts/generateHeaderCrosswalk.js",
-    "prestart": "npm run generate:crosswalk",
-    "prebuild": "npm run generate:crosswalk",
-    "pretest": "npm run generate:crosswalk",
+    "prepare:sqlite-assets": "node scripts/prepareSqliteAssets.js",
+    "build:sqlite": "node scripts/build-sqlite.js",
+    "build:sqlite:batch": "python3 scripts/build-sqlite-batch.py",
+    "sync:sqlite-assets": "python3 scripts/sync-sqlite-assets.py",
+    "prestart": "npm run generate:crosswalk && npm run prepare:sqlite-assets",
+    "prebuild": "npm run generate:crosswalk && npm run prepare:sqlite-assets",
+    "pretest": "npm run generate:crosswalk && npm run prepare:sqlite-assets",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
@@ -50,6 +55,9 @@
   },
   "devDependencies": {
     "gh-pages": "^6.3.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "sql.js": "^1.11.0",
+    "sql.js-httpvfs": "^0.7.7",
+    "xxhash-wasm": "^1.1.0"
   }
 }

--- a/csv_viewer_app/scripts/build-sqlite-batch.py
+++ b/csv_viewer_app/scripts/build-sqlite-batch.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Batch builder for SQLite search bundles.
+
+Scans one or more source directories for Tuva CSV exports, estimates row
+counts, and invokes ``scripts/build-sqlite.js`` for datasets that exceed the
+preview threshold (defaults to 1,000 rows).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, Iterator, List, Sequence, Tuple
+
+PREVIEW_THRESHOLD = 1000
+SUPPORTED_SUFFIXES = (".csv", ".csv.gz")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch build SQLite search bundles")
+    parser.add_argument(
+        "sources",
+        nargs="+",
+        help="Directories or files to scan (e.g. ../data/versioned_terminology/latest)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=PREVIEW_THRESHOLD,
+        help="Minimum row count before a dataset is built (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        dest="datasets",
+        help="Restrict processing to specific dataset ids (can be repeated)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Override output directory passed to build-sqlite.js",
+    )
+    parser.add_argument(
+        "--label-prefix",
+        help="Prefix labels recorded in datasets.json (optional)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the actions without running build-sqlite.js",
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Keep temporary files created for multi-part datasets",
+    )
+    return parser.parse_args(argv)
+
+
+def iter_source_files(path: Path) -> Iterator[Path]:
+    if path.is_file():
+        if path.name.endswith(SUPPORTED_SUFFIXES):
+            yield path
+        return
+    if not path.is_dir():
+        return
+    for file_path in sorted(path.rglob("*")):
+        if not file_path.is_file():
+            continue
+        name = file_path.name
+        if name.endswith(SUPPORTED_SUFFIXES) and ".index" not in name:
+            yield file_path
+
+
+def dataset_key_for(path: Path) -> Tuple[str, Path]:
+    name = path.name
+    without_gz = name[:-3] if name.endswith(".gz") else name
+    if ".csv" not in without_gz:
+        base = without_gz
+    else:
+        base = without_gz.split(".csv", 1)[0]
+    # Dataset id is everything before the first ".csv" marker
+    dataset_id = base
+    return dataset_id, path
+
+
+def group_datasets(files: Iterable[Path]) -> dict[str, List[Path]]:
+    grouped: dict[str, List[Path]] = {}
+    for file_path in files:
+        dataset_id, original_path = dataset_key_for(file_path)
+        grouped.setdefault(dataset_id, []).append(original_path)
+    for paths in grouped.values():
+        paths.sort()
+    return grouped
+
+
+def open_dataset(path: Path) -> Iterator[str]:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                yield line
+    else:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                yield line
+
+
+def count_rows(path: Path, threshold: int) -> int:
+    """Return the number of data rows (excluding header) up to threshold+1."""
+    lines = open_dataset(path)
+    try:
+        next(lines)  # header
+    except StopIteration:
+        return 0
+    count = 0
+    for _ in lines:
+        count += 1
+        if count > threshold:
+            break
+    return count
+
+
+def combine_chunks(dataset_id: str, files: Sequence[Path]) -> Path:
+    temp = tempfile.NamedTemporaryFile(prefix=f"{dataset_id}_", suffix=".csv", delete=False)
+    temp_path = Path(temp.name)
+    temp.close()
+    with temp_path.open("w", encoding="utf-8") as sink:
+        first_file = True
+        for file_path in files:
+            for idx, line in enumerate(open_dataset(file_path)):
+                if first_file or idx > 0:
+                    sink.write(line)
+            first_file = False
+    return temp_path
+
+
+def build_sqlite(dataset_id: str, input_path: Path, args: argparse.Namespace) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "build-sqlite.js"
+    command = ["node", str(script_path), "--input", str(input_path), "--dataset", dataset_id]
+    if args.output:
+        command.extend(["--output", args.output])
+    if args.label_prefix:
+        command.extend(["--label", f"{args.label_prefix}{dataset_id}"])
+    if args.dry_run:
+        print("DRY RUN:", shlex.join(command))
+        return
+    print(shlex.join(command))
+    subprocess.run(command, cwd=repo_root, check=True)
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    threshold = max(0, args.threshold)
+    dataset_filter = {name.lower() for name in (args.datasets or [])}
+
+    source_paths = [Path(src).resolve() for src in args.sources]
+    files = []
+    for source in source_paths:
+        files.extend(iter_source_files(source))
+
+    grouped = group_datasets(files)
+    if not grouped:
+        print("No datasets found.")
+        return 0
+
+    for dataset_id, paths in sorted(grouped.items()):
+        if dataset_id.endswith("_compressed"):
+            print(f"Skipping {dataset_id}: marked as compressed duplicate.")
+            continue
+        if dataset_filter and dataset_id.lower() not in dataset_filter:
+            continue
+
+        estimated_rows = 0
+        for file_path in paths:
+            estimated_rows += count_rows(file_path, threshold)
+            if estimated_rows > threshold:
+                break
+
+        if estimated_rows <= threshold:
+            print(f"Skipping {dataset_id}: {estimated_rows} rows (<= {threshold}).")
+            continue
+
+        input_path = paths[0]
+        temp_path: Path | None = None
+        try:
+            if len(paths) > 1:
+                print(f"Combining {len(paths)} chunks for {dataset_id}...")
+                temp_path = combine_chunks(dataset_id, paths)
+                input_path = temp_path
+
+            build_sqlite(dataset_id, input_path, args)
+        finally:
+            if temp_path and not args.keep_temp and not args.dry_run:
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/csv_viewer_app/scripts/build-sqlite.js
+++ b/csv_viewer_app/scripts/build-sqlite.js
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+
+/**
+ * Builds SQLite FTS databases for CSV datasets so that the frontend can stream
+ * pages on demand over HTTP range requests. The script produces the following
+ * artefacts per dataset:
+ *  - `<dataset>/<dataset>.sqlite[.shardN]`
+ *  - `<dataset>/manifest.json`
+ *  - `<dataset>/preview.json`
+ *  - optional routing headers when sharding is enabled.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const Papa = require('papaparse');
+const Database = require('better-sqlite3');
+const { createHash } = require('crypto');
+const zlib = require('zlib');
+const xxhashFactory = require('xxhash-wasm');
+
+const DEFAULT_MAX_SHARD_BYTES = 120 * 1024 * 1024; // 120 MB
+const DEFAULT_PREVIEW_LIMIT = 1000;
+const ROUTING_MAX_NGRAMS = 6000;
+const ROUTING_MIN_LENGTH = 2;
+const ROUTING_MAX_LENGTH = 3;
+const TOKEN_NORMALIZE_REGEX = /[^a-z0-9\-._\s]+/g;
+const DIACRITIC_REGEX = /[\u0300-\u036f]/g;
+const GENERATED_COLUMN_PREFIX = 'column_';
+
+function quoteIdentifier(value) {
+  const text = String(value ?? '').replace(/"/g, '""');
+  return `"${text}"`;
+}
+
+function loadJsonFile(filePath) {
+  const buffer = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(buffer);
+}
+
+function loadCrosswalk(crosswalkPath, repoRoot) {
+  const resolved = crosswalkPath
+    ? path.resolve(crosswalkPath)
+    : path.join(repoRoot, 'public', 'data', 'header-crosswalk.json');
+  try {
+    return loadJsonFile(resolved);
+  } catch (error) {
+    console.warn(`Warning: unable to load header crosswalk from ${resolved}: ${error.message}`);
+  }
+  return null;
+}
+
+function resolveCrosswalkHeaders(crosswalk, datasetId, inputPath) {
+  if (!crosswalk) {
+    return null;
+  }
+  const datasetKey = `${datasetId}.csv`;
+  const pathSegments = inputPath ? path.resolve(inputPath).split(path.sep) : [];
+  const candidateRoots = new Set();
+  Object.keys(crosswalk).forEach((key) => {
+    if (key.startsWith('_')) {
+      return;
+    }
+    if (pathSegments.includes(key)) {
+      candidateRoots.add(key);
+    }
+  });
+
+  const matches = [];
+  Object.entries(crosswalk).forEach(([root, versions]) => {
+    if (root.startsWith('_')) {
+      return;
+    }
+    if (candidateRoots.size && !candidateRoots.has(root)) {
+      return;
+    }
+    Object.entries(versions || {}).forEach(([version, datasets]) => {
+      const details = datasets?.[datasetKey];
+      if (details?.headers?.length) {
+        matches.push({ root, version, headers: details.headers });
+      }
+    });
+  });
+
+  if (!matches.length) {
+    return null;
+  }
+
+  const seen = new Set();
+  const unique = [];
+  matches.forEach((entry) => {
+    const signature = JSON.stringify(entry.headers);
+    if (!seen.has(signature)) {
+      unique.push(entry);
+      seen.add(signature);
+    }
+  });
+
+  const preferred = unique[unique.length - 1];
+  return preferred.headers;
+}
+
+function createInputStream(filePath) {
+  const resolved = path.resolve(filePath);
+  if (resolved.endsWith('.gz')) {
+    const source = fs.createReadStream(resolved);
+    const gunzip = zlib.createGunzip();
+    source.on('error', (error) => {
+      gunzip.emit('error', error);
+    });
+    gunzip.setEncoding('utf8');
+    return source.pipe(gunzip);
+  }
+  return fs.createReadStream(resolved, { encoding: 'utf8' });
+}
+
+function normalisedDatasetKeys(datasetId, fileName) {
+  const values = new Set();
+  const add = (value) => {
+    if (value != null && value !== '') {
+      values.add(String(value).toLowerCase());
+    }
+  };
+
+  if (datasetId) {
+    add(datasetId);
+    add(`${datasetId}.csv`);
+  }
+
+  if (fileName) {
+    add(fileName);
+    if (fileName.endsWith('.gz')) {
+      add(fileName.slice(0, -3));
+    }
+    const lower = fileName.toLowerCase();
+    const csvIndex = lower.indexOf('.csv');
+    if (csvIndex !== -1) {
+      add(lower.slice(0, csvIndex));
+      add(lower.slice(0, csvIndex + 4));
+    }
+  }
+
+  return Array.from(values);
+}
+
+function usage(error) {
+  if (error) {
+    console.error(error);
+  }
+  console.log(`Usage: build-sqlite.js --input <file> --dataset <id> [options]
+
+Required:
+  --input <path>            CSV or Parquet file to ingest (CSV assumed for now)
+  --dataset <id>            Dataset identifier (used for output folder naming)
+
+Options:
+  --output <dir>            Output directory (default: public/data/sqlite)
+  --limits <path>           limits.json path (default: src/config/limits.json)
+  --crosswalk <path>        header crosswalk JSON path (default: public/data/header-crosswalk.json)
+  --shard-count <n>         Explicit shard count override
+  --max-shard-bytes <n>     Target max uncompressed bytes per shard (default 125829120)
+  --shard-key <cols>        Comma separated column names used for shard hashing
+  --preview-limit <n>       Number of rows in preview payload (default 1000)
+  --skip-preview            Do not emit preview.json
+  --label <text>            Human readable dataset label for manifest index
+  --help                    Show this message
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    input: null,
+    dataset: null,
+    output: null,
+    limitsPath: null,
+    crosswalkPath: null,
+    shardCount: null,
+    maxShardBytes: DEFAULT_MAX_SHARD_BYTES,
+    shardKey: [],
+    previewLimit: DEFAULT_PREVIEW_LIMIT,
+    skipPreview: false,
+    label: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--input':
+        options.input = argv[++i];
+        break;
+      case '--dataset':
+        options.dataset = argv[++i];
+        break;
+      case '--output':
+        options.output = argv[++i];
+        break;
+      case '--limits':
+        options.limitsPath = argv[++i];
+        break;
+      case '--crosswalk':
+        options.crosswalkPath = argv[++i];
+        break;
+      case '--shard-count':
+        options.shardCount = Number.parseInt(argv[++i], 10);
+        if (!Number.isFinite(options.shardCount) || options.shardCount < 1) {
+          throw new Error('--shard-count must be a positive integer');
+        }
+        break;
+      case '--max-shard-bytes':
+        options.maxShardBytes = Number.parseInt(argv[++i], 10);
+        if (!Number.isFinite(options.maxShardBytes) || options.maxShardBytes < 4 * 1024 * 1024) {
+          throw new Error('--max-shard-bytes must be >= 4MB');
+        }
+        break;
+      case '--shard-key': {
+        const raw = argv[++i];
+        options.shardKey = raw.split(',').map((value) => value.trim()).filter(Boolean);
+        break;
+      }
+      case '--preview-limit':
+        options.previewLimit = Number.parseInt(argv[++i], 10);
+        if (!Number.isFinite(options.previewLimit) || options.previewLimit < 0) {
+          throw new Error('--preview-limit must be >= 0');
+        }
+        break;
+      case '--skip-preview':
+        options.skipPreview = true;
+        break;
+      case '--label':
+        options.label = argv[++i];
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.input) {
+    throw new Error('Missing required --input argument');
+  }
+  if (!options.dataset) {
+    throw new Error('Missing required --dataset argument');
+  }
+
+  return options;
+}
+
+function loadLimits(limitsPath, repoRoot) {
+  const resolved = limitsPath
+    ? path.resolve(limitsPath)
+    : path.join(repoRoot, 'src', 'config', 'limits.json');
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(resolved);
+  } catch (error) {
+    console.warn(`Warning: unable to load limits from ${resolved}: ${error.message}`);
+  }
+  return {};
+}
+
+function resolveValueColumnLimit(datasetId, inputFileName, limits) {
+  const defaultLimit = Number.isFinite(limits?.indexValueColumnLimit)
+    ? Math.max(1, Math.floor(limits.indexValueColumnLimit))
+    : 8;
+  const overrides = limits?.indexValueColumnLimitOverrides || {};
+  const overridesLower = Object.entries(overrides).reduce((acc, [key, value]) => {
+    acc[String(key).toLowerCase()] = value;
+    return acc;
+  }, {});
+  const candidates = normalisedDatasetKeys(datasetId, inputFileName);
+  for (const candidate of candidates) {
+    if (Object.prototype.hasOwnProperty.call(overridesLower, candidate)) {
+      const override = overridesLower[candidate];
+      if (Number.isFinite(override) && override >= 1) {
+        return Math.floor(override);
+      }
+    }
+  }
+  return defaultLimit;
+}
+
+function isDatasetExcluded(datasetId, inputFileName, limits) {
+  const exclusions = Array.isArray(limits?.indexDatasetExclusions) ? limits.indexDatasetExclusions : [];
+  const exclusionSet = new Set(exclusions.map((entry) => String(entry || '').toLowerCase()));
+  const candidates = normalisedDatasetKeys(datasetId, inputFileName);
+  return candidates.some((candidate) => exclusionSet.has(candidate));
+}
+
+function normalizeTokenSource(value) {
+  if (value == null) {
+    return '';
+  }
+  const stringValue = String(value)
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(DIACRITIC_REGEX, '')
+    .replace(TOKEN_NORMALIZE_REGEX, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stringValue;
+}
+
+function collectNgramsFromTokens(tokens, set) {
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+    const compact = token.replace(/\s+/g, '');
+    for (let length = ROUTING_MIN_LENGTH; length <= ROUTING_MAX_LENGTH; length += 1) {
+      if (compact.length < length) {
+        continue;
+      }
+      for (let index = 0; index <= compact.length - length; index += 1) {
+        const ngram = compact.slice(index, index + length);
+        set.add(ngram);
+        if (set.size >= ROUTING_MAX_NGRAMS) {
+          return;
+        }
+      }
+    }
+  }
+}
+
+function tokenizeForRouting(row, columns) {
+  const tokens = [];
+  for (const column of columns) {
+    const raw = row[column];
+    const normalized = normalizeTokenSource(raw);
+    if (normalized) {
+      tokens.push(...normalized.split(' '));
+    }
+  }
+  return tokens;
+}
+
+function sanitizeValue(value) {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : null;
+  }
+  return String(value);
+}
+
+async function computeSha256(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => {
+      hash.update(chunk);
+    });
+    stream.on('error', reject);
+    stream.on('end', () => {
+      resolve(hash.digest('hex'));
+    });
+  });
+}
+
+function createSchema(db, narrowColumns, extraColumns) {
+  const rawColumnsDDL = narrowColumns.map((column) => `${quoteIdentifier(column)} TEXT`).join(', ');
+  db.exec(`CREATE TABLE t_raw (
+    rowid INTEGER PRIMARY KEY,
+    ${rawColumnsDDL}
+  );`);
+
+  if (extraColumns.length) {
+    db.exec('CREATE TABLE t_extra (rowid INTEGER PRIMARY KEY, payload TEXT NOT NULL);');
+  }
+
+  const ftsColumnsDDL = narrowColumns.map((column) => quoteIdentifier(column)).join(', ');
+  db.exec(`CREATE VIRTUAL TABLE t_fts USING fts5(
+    ${ftsColumnsDDL},
+    content='t_raw',
+    content_rowid='rowid',
+    tokenize="unicode61 tokenchars '-._'",
+    prefix='2 3'
+  );`);
+
+  db.exec('CREATE INDEX idx_raw_rowid ON t_raw(rowid);');
+  if (extraColumns.length) {
+    db.exec('CREATE INDEX idx_extra_rowid ON t_extra(rowid);');
+  }
+}
+
+function createShardContexts(params) {
+  const {
+    outputDir,
+    shardCount,
+    dataset,
+    narrowColumns,
+    extraColumns,
+  } = params;
+
+  const contexts = [];
+  for (let shard = 0; shard < shardCount; shard += 1) {
+    const suffix = shardCount === 1 ? '' : `.shard${String(shard).padStart(2, '0')}`;
+    const fileName = `${dataset}${suffix}.sqlite`;
+    const filePath = path.join(outputDir, fileName);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+    const db = new Database(filePath);
+    db.pragma('page_size = 4096');
+    db.pragma('journal_mode = OFF');
+    db.pragma('synchronous = OFF');
+    db.pragma('temp_store = MEMORY');
+    db.exec('PRAGMA locking_mode = EXCLUSIVE;');
+    createSchema(db, narrowColumns, extraColumns);
+    db.exec('BEGIN IMMEDIATE TRANSACTION;');
+
+    const insertPlaceholders = new Array(narrowColumns.length).fill('?').join(', ');
+    const insertRawSql = `INSERT INTO t_raw(rowid, ${narrowColumns.map((c) => quoteIdentifier(c)).join(', ')}) VALUES (?, ${insertPlaceholders});`;
+    const insertRawStmt = db.prepare(insertRawSql);
+
+    let insertExtraStmt = null;
+    if (extraColumns.length) {
+      insertExtraStmt = db.prepare('INSERT INTO t_extra(rowid, payload) VALUES (?, ?);');
+    }
+
+    const insertFtsSql = `INSERT INTO t_fts(rowid, ${narrowColumns.map((c) => quoteIdentifier(c)).join(', ')}) VALUES (?, ${insertPlaceholders});`;
+    const insertFtsStmt = db.prepare(insertFtsSql);
+
+    contexts.push({
+      shard,
+      fileName,
+      filePath,
+      db,
+      insertRawStmt,
+      insertExtraStmt,
+      insertFtsStmt,
+      rowCount: 0,
+      routingSet: new Set(),
+      narrowColumns,
+      extraColumns,
+    });
+  }
+  return contexts;
+}
+
+function closeStatements(context) {
+  if (context.insertRawStmt) {
+    context.insertRawStmt = null;
+  }
+  if (context.insertExtraStmt) {
+    context.insertExtraStmt = null;
+  }
+  if (context.insertFtsStmt) {
+    context.insertFtsStmt = null;
+  }
+}
+
+async function finalizeContext(context) {
+  const { db } = context;
+  try {
+    db.exec('COMMIT;');
+    db.exec('ANALYZE;');
+    db.exec('PRAGMA optimize;');
+    db.exec('VACUUM;');
+  } finally {
+    db.close();
+  }
+  const stats = await fsp.stat(context.filePath);
+  const sha256 = await computeSha256(context.filePath);
+  context.sizeBytes = stats.size;
+  context.sha256 = sha256;
+}
+
+function writePreviewFile(datasetDir, datasetId, columns, rows) {
+  const filePath = path.join(datasetDir, 'preview.json');
+  const payload = {
+    datasetId,
+    generatedAt: new Date().toISOString(),
+    columns,
+    rows,
+  };
+  return fsp.writeFile(filePath, JSON.stringify(payload));
+}
+
+async function writeRoutingHeader(datasetDir, datasetId, context) {
+  if (!context.routingSet.size) {
+    return null;
+  }
+  const sorted = Array.from(context.routingSet).sort();
+  const fileName = `${datasetId}.shard${String(context.shard).padStart(2, '0')}.routing.json`;
+  const filePath = path.join(datasetDir, fileName);
+  const payload = {
+    datasetId,
+    shard: context.shard,
+    strategy: 'ngram',
+    prefixLengths: [2, 3],
+    ngrams: sorted.slice(0, ROUTING_MAX_NGRAMS),
+  };
+  await fsp.writeFile(filePath, JSON.stringify(payload));
+  return fileName;
+}
+
+async function updateDatasetsIndex(indexPath, entry) {
+  let current = [];
+  try {
+    const buffer = await fsp.readFile(indexPath, 'utf8');
+    current = JSON.parse(buffer);
+    if (!Array.isArray(current)) {
+      current = [];
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const filtered = current.filter((item) => item.datasetId !== entry.datasetId);
+  filtered.push(entry);
+  filtered.sort((a, b) => a.datasetId.localeCompare(b.datasetId));
+  await fsp.writeFile(indexPath, JSON.stringify(filtered, null, 2));
+}
+
+async function main() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const args = parseArgs(process.argv.slice(2));
+  const inputPath = path.resolve(args.input);
+  const datasetId = args.dataset;
+  const outputRoot = args.output ? path.resolve(args.output) : path.join(repoRoot, 'public', 'data', 'sqlite');
+  const datasetDir = path.join(outputRoot, datasetId);
+  await fsp.mkdir(datasetDir, { recursive: true });
+
+  const limits = loadLimits(args.limitsPath, repoRoot);
+  const inputFileName = path.basename(inputPath);
+  if (isDatasetExcluded(datasetId, inputFileName, limits)) {
+    console.error(`Dataset ${datasetId} excluded by limits configuration. Skipping.`);
+    return;
+  }
+
+  const stats = await fsp.stat(inputPath);
+  if (!stats.isFile()) {
+    throw new Error(`Input path ${inputPath} is not a file`);
+  }
+
+  const valueColumnLimit = resolveValueColumnLimit(datasetId, inputFileName, limits);
+  const label = args.label || datasetId;
+
+  const shardCount = args.shardCount || Math.max(1, Math.ceil(stats.size / args.maxShardBytes));
+
+  const hashRuntime = await xxhashFactory();
+
+  const crosswalk = loadCrosswalk(args.crosswalkPath, repoRoot);
+  const crosswalkHeaders = resolveCrosswalkHeaders(crosswalk, datasetId, inputPath);
+  const useCrosswalkHeaders = Array.isArray(crosswalkHeaders) && crosswalkHeaders.length > 0;
+  if (useCrosswalkHeaders) {
+    console.log(`Using ${crosswalkHeaders.length} header(s) from crosswalk for ${datasetId}.`);
+  } else {
+    console.log(`No crosswalk headers found for ${datasetId}; using the first row of the file.`);
+  }
+
+  let columns = useCrosswalkHeaders ? [...crosswalkHeaders] : [];
+  let narrowColumns = useCrosswalkHeaders
+    ? columns.slice(0, Math.min(columns.length, valueColumnLimit))
+    : [];
+  let extraColumns = useCrosswalkHeaders ? columns.slice(narrowColumns.length) : [];
+  let contexts = [];
+  let rowId = 0;
+  const previewRows = [];
+  let maxColumns = columns.length;
+
+  const shardKeyColumns = args.shardKey.length ? args.shardKey : null;
+
+  const papaConfig = {
+    header: !useCrosswalkHeaders,
+    skipEmptyLines: 'greedy',
+    transformHeader: (header) => header.trim(),
+  };
+
+  const inputStream = createInputStream(inputPath);
+  const papaStream = Papa.parse(Papa.NODE_STREAM_INPUT, papaConfig);
+
+  let resolveStream;
+  let rejectStream;
+  const completion = new Promise((resolve, reject) => {
+    resolveStream = resolve;
+    rejectStream = reject;
+  });
+
+  papaStream.on('error', (error) => {
+    rejectStream(error);
+  });
+
+  papaStream.on('data', (row) => {
+    let record = row;
+
+    if (useCrosswalkHeaders) {
+      const values = Array.isArray(row) ? row : Object.values(row);
+      if (!contexts.length && values.length > columns.length) {
+        for (let index = columns.length; index < values.length; index += 1) {
+          columns.push(`${GENERATED_COLUMN_PREFIX}${index + 1}`);
+        }
+        narrowColumns = columns.slice(0, Math.min(columns.length, valueColumnLimit));
+        extraColumns = columns.slice(narrowColumns.length);
+      } else if (contexts.length && values.length > columns.length) {
+        throw new Error(`Row ${rowId + 1} contains more columns than the schema allows for ${datasetId}.`);
+      }
+      record = {};
+      for (let index = 0; index < columns.length; index += 1) {
+        record[columns[index]] = values[index] ?? null;
+      }
+    } else if (!columns.length) {
+      columns = Object.keys(row);
+      narrowColumns = columns.slice(0, Math.min(columns.length, valueColumnLimit));
+      extraColumns = columns.slice(narrowColumns.length);
+    }
+
+    if (!contexts.length) {
+      contexts = createShardContexts({
+        outputDir: datasetDir,
+        shardCount,
+        dataset: datasetId,
+        narrowColumns,
+        extraColumns,
+      });
+    }
+
+    maxColumns = Math.max(maxColumns, columns.length);
+    rowId += 1;
+
+    const displayValues = narrowColumns.map((column) => {
+      const value = sanitizeValue(record[column]);
+      return value == null ? null : String(value);
+    });
+
+    const extraPayload = {};
+    if (extraColumns.length) {
+      for (const column of extraColumns) {
+        const value = sanitizeValue(record[column]);
+        if (value != null) {
+          extraPayload[column] = value;
+        }
+      }
+    }
+
+    const normalizedKeySource = (shardKeyColumns && shardKeyColumns.length)
+      ? shardKeyColumns.map((column) => normalizeTokenSource(record[column])).join('|')
+      : normalizeTokenSource(displayValues.map((value) => (value == null ? '' : value)).join(' '));
+    const shardIndex = contexts.length === 1
+      ? 0
+      : Number(hashRuntime.h32(normalizedKeySource) % contexts.length);
+    const context = contexts[shardIndex];
+
+    context.insertRawStmt.run(rowId, ...displayValues);
+    const ftsValues = narrowColumns.map((column) => {
+      const normalized = normalizeTokenSource(record[column]);
+      return normalized || null;
+    });
+    context.insertFtsStmt.run(rowId, ...ftsValues);
+    if (context.insertExtraStmt && Object.keys(extraPayload).length) {
+      context.insertExtraStmt.run(rowId, JSON.stringify(extraPayload));
+    }
+    context.rowCount += 1;
+
+    if (contexts.length > 1) {
+      const tokens = tokenizeForRouting(record, narrowColumns);
+      if (tokens.length && context.routingSet.size < ROUTING_MAX_NGRAMS) {
+        collectNgramsFromTokens(tokens, context.routingSet);
+      }
+    }
+
+    if (!args.skipPreview && previewRows.length < args.previewLimit) {
+      const previewRow = columns.map((column) => {
+        const value = sanitizeValue(record[column]);
+        return value == null ? null : value;
+      });
+      previewRows.push(previewRow);
+    }
+  });
+
+  papaStream.on('end', () => {
+    resolveStream();
+  });
+
+  inputStream.pipe(papaStream);
+
+  await completion;
+
+  if (rowId === 0) {
+    console.warn(`Input ${inputPath} yielded no rows. Nothing to build.`);
+    return;
+  }
+
+  for (const context of contexts) {
+    closeStatements(context);
+    await finalizeContext(context);
+  }
+
+  if (!args.skipPreview && previewRows.length) {
+    await writePreviewFile(datasetDir, datasetId, columns, previewRows);
+  }
+
+  const routingFiles = [];
+  if (contexts.length > 1) {
+    for (const context of contexts) {
+      const routingFile = await writeRoutingHeader(datasetDir, datasetId, context);
+      routingFiles.push(routingFile);
+    }
+  }
+
+  const manifest = {
+    datasetId,
+    label,
+    generatedAt: new Date().toISOString(),
+    rowCount: rowId,
+    maxColumns,
+    narrowColumns,
+    extraColumns,
+    shardCount: contexts.length,
+    pageSizeBytes: 4096,
+    resources: contexts.map((context, index) => ({
+      shard: index,
+      file: context.fileName,
+      size: context.sizeBytes,
+      sha256: context.sha256,
+      url: `./${context.fileName}`,
+      routing: routingFiles[index] ? `./${routingFiles[index]}` : null,
+      rowCount: context.rowCount,
+    })),
+    preview: (!args.skipPreview && previewRows.length)
+      ? {
+        url: './preview.json',
+        rows: previewRows.length,
+      }
+      : null,
+    fts: {
+      tokenize: "unicode61 tokenchars '-._'",
+      prefix: ['2', '3'],
+    },
+    options: {
+      shardKeyColumns,
+      maxShardBytes: args.maxShardBytes,
+    },
+  };
+
+  const manifestPath = path.join(datasetDir, 'manifest.json');
+  await fsp.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+  const indexEntry = {
+    datasetId,
+    label,
+    manifest: `./${datasetId}/manifest.json`,
+    generatedAt: manifest.generatedAt,
+    rowCount: rowId,
+    shardCount: contexts.length,
+  };
+  const indexPath = path.join(outputRoot, 'datasets.json');
+  await updateDatasetsIndex(indexPath, indexEntry);
+
+  console.log(`Built SQLite FTS artefacts for ${datasetId}: ${contexts.length} shard(s)`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/csv_viewer_app/scripts/prepareSqliteAssets.js
+++ b/csv_viewer_app/scripts/prepareSqliteAssets.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/*
+ * Copies the sql.js WebAssembly artefacts into public/sqljs so the runtime can
+ * resolve them via locateFile when initialising the HTTP VFS layer.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEST_DIR = path.join(REPO_ROOT, 'public', 'sqljs');
+
+async function ensureDir(target) {
+  await fsp.mkdir(target, { recursive: true });
+}
+
+async function main() {
+  let sqlJsRoot;
+  try {
+    const pkgJsonPath = require.resolve('sql.js/package.json', { paths: [REPO_ROOT] });
+    sqlJsRoot = path.dirname(pkgJsonPath);
+  } catch (error) {
+    console.error('Unable to resolve sql.js. Please install dependencies first.');
+    process.exitCode = 1;
+    return;
+  }
+
+  let wasmSource;
+  const wasmDest = path.join(DEST_DIR, 'sql-wasm.wasm');
+  let workerSource;
+  let workerMapSource;
+  let httpvfsBundleSource;
+  try {
+    const httpvfsRoot = path.dirname(require.resolve('sql.js-httpvfs/dist/sqlite.worker.js', { paths: [REPO_ROOT] }));
+    workerSource = path.join(httpvfsRoot, 'sqlite.worker.js');
+    workerMapSource = path.join(httpvfsRoot, 'sqlite.worker.js.map');
+    httpvfsBundleSource = path.join(httpvfsRoot, 'index.js');
+    wasmSource = path.join(httpvfsRoot, 'sql-wasm.wasm');
+  } catch (error) {
+    console.error('Unable to resolve sql.js-httpvfs worker bundle.');
+    process.exitCode = 1;
+    return;
+  }
+  const workerDest = path.join(DEST_DIR, 'sqlite.worker.js');
+  const workerMapDest = path.join(DEST_DIR, 'sqlite.worker.js.map');
+  const httpvfsBundleDest = path.join(DEST_DIR, 'sqljs-httpvfs.js');
+
+  await ensureDir(DEST_DIR);
+  await fsp.copyFile(wasmSource, wasmDest);
+  await fsp.copyFile(workerSource, workerDest);
+  if (fs.existsSync(workerMapSource)) {
+    await fsp.copyFile(workerMapSource, workerMapDest);
+  }
+  if (httpvfsBundleSource) {
+    await fsp.copyFile(httpvfsBundleSource, httpvfsBundleDest);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/csv_viewer_app/scripts/sync-sqlite-assets.py
+++ b/csv_viewer_app/scripts/sync-sqlite-assets.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""End-to-end helper for SQLite asset builds and S3 sync.
+
+This script can optionally download the current bundle set from S3, run the
+local batch builder against one or more Tuva export directories, and then sync
+any updated artefacts back to the same prefix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Sequence
+
+DEFAULT_OUTPUT = Path("public/data/sqlite")
+DEFAULT_THRESHOLD = 1000
+DEFAULT_S3_PREFIX = "s3://tuva-public-resources/terminology_viewer_sqlite"
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build SQLite bundles and sync with S3")
+    parser.add_argument(
+        "sources",
+        nargs="*",
+        help="Dataset directories to process (e.g. ../data/versioned_terminology/latest)",
+    )
+    parser.add_argument(
+        "--s3-uri",
+        default=DEFAULT_S3_PREFIX,
+        help=f"S3 URI where SQLite bundles are stored (default: {DEFAULT_S3_PREFIX})",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help=f"Local output directory (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help="Row-count threshold passed to build-sqlite-batch (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        dest="datasets",
+        help="Restrict processing to specific dataset ids (repeatable)",
+    )
+    parser.add_argument(
+        "--download-only",
+        action="store_true",
+        help="Only sync from S3 to local output, skip build/upload",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Skip the initial S3 download step",
+    )
+    parser.add_argument(
+        "--skip-upload",
+        action="store_true",
+        help="Skip the final S3 upload step",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands instead of executing them",
+    )
+    parser.add_argument(
+        "--aws-profile",
+        help="AWS profile name to use for s3 sync commands",
+    )
+    parser.add_argument(
+        "--extra-batch-args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments passed verbatim to build-sqlite-batch.py (after '--')",
+    )
+    return parser.parse_args(argv)
+
+
+def run_command(command: List[str], *, cwd: Path | None = None, dry_run: bool = False) -> None:
+    text = shlex.join(command)
+    if dry_run:
+        print(f"DRY RUN: {text}")
+        return
+    print(text)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def ensure_command(name: str) -> None:
+    if shutil.which(name) is None:
+        raise RuntimeError(f"Required command '{name}' not found on PATH")
+
+
+def sync_from_s3(s3_uri: str, output: Path, *, profile: str | None, dry_run: bool) -> None:
+    command = ["aws", "s3", "sync", s3_uri, str(output)]
+    if profile:
+        command.extend(["--profile", profile])
+    run_command(command, dry_run=dry_run)
+
+
+def sync_to_s3(output: Path, s3_uri: str, *, profile: str | None, dry_run: bool) -> None:
+    command = ["aws", "s3", "sync", str(output), s3_uri]
+    if profile:
+        command.extend(["--profile", profile])
+    run_command(command, dry_run=dry_run)
+
+
+def run_batch_builder(
+    sources: Sequence[str],
+    output: Path,
+    args: argparse.Namespace,
+    repo_root: Path,
+) -> None:
+    if not sources:
+        print("No sources supplied; skipping build step.")
+        return
+    builder = repo_root / "scripts" / "build-sqlite-batch.py"
+    command = [
+        sys.executable,
+        str(builder),
+        "--threshold",
+        str(max(0, args.threshold)),
+        "--output",
+        str(output),
+    ]
+    if args.datasets:
+        for dataset in args.datasets:
+            command.extend(["--dataset", dataset])
+    command.extend(sources)
+    if args.extra_batch_args:
+        command.extend(args.extra_batch_args)
+    run_command(command, cwd=repo_root, dry_run=args.dry_run)
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    output = Path(args.output).resolve()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    output.mkdir(parents=True, exist_ok=True)
+
+    try:
+        ensure_command("aws")
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    if not args.skip_download:
+        sync_from_s3(args.s3_uri, output, profile=args.aws_profile, dry_run=args.dry_run)
+        if args.download_only:
+            return 0
+
+    run_batch_builder(args.sources, output, args, repo_root)
+
+    if not args.skip_upload:
+        sync_to_s3(output, args.s3_uri, profile=args.aws_profile, dry_run=args.dry_run)
+
+    return 0
+
+
+if __name__ == "__main__":
+    import shutil
+
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add scripts for building SQLite bundles, batching datasets, and syncing to S3
- expose the tooling via npm scripts and required dependencies
- document the SQLite asset workflow for the terminology viewer

## Testing
- not run (tooling depends on external datasets and native modules)

------
https://chatgpt.com/codex/tasks/task_e_68dae5c973848332aa27716cb6c0f87c