### PR TITLE
Fix sqlite worker asset path resolution

### DIFF
--- a/csv_viewer_app/public/workers/searchWorker.js
+++ b/csv_viewer_app/public/workers/searchWorker.js
@@ -221,8 +221,8 @@ async function openShard(shardIndex) {
     message: `opening shard ${shardIndex}: ${virtualFilename} from ${fileUrl}`,
   });
 
-  const workerUrl = resolveUrl('../sqljs/sqlite.worker.js', state.assetBaseUrl);
-  const wasmUrl = resolveUrl('../sqljs/sql-wasm.wasm', state.assetBaseUrl);
+  const workerUrl = resolveUrl('sqljs/sqlite.worker.js', state.assetBaseUrl);
+  const wasmUrl = resolveUrl('sqljs/sql-wasm.wasm', state.assetBaseUrl);
 
   const config = {
     virtualFilename,


### PR DESCRIPTION
## Summary
- resolve the sql.js worker and wasm assets relative to the configured asset base so they load correctly when the app is served from a sub-path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe733059c8332978441946b0a39e0